### PR TITLE
Update remove_debugging_statements.yaml

### DIFF
--- a/remove_debugging_statements.yaml
+++ b/remove_debugging_statements.yaml
@@ -45,3 +45,13 @@ rules:
   - no-match: custom_print("sth")
   tags:
   - no-debug
+  
+- id: flag-streamlit-show
+  description: streamlit`s `experimental_show` in production code
+  pattern: ${package}.experimental_show(...)
+  replacement: ""
+  tests:
+    - match: st.experimental_show(df)
+    - match: streamlit.experimental_show(df)
+    - no-match: st.snow(df)
+


### PR DESCRIPTION
The streamlit package provides the function "experimental_show()" to show objects for debugging purposes. The "flag-streamlit-show"-rule lets you delete those lines quickly after you don't need them anymore.