### PR TITLE
Do not require docstring for __init__.py

### DIFF
--- a/google-python-style-guide.yaml
+++ b/google-python-style-guide.yaml
@@ -721,6 +721,7 @@ rules:
     exclude:
     - test_*.py
     - '*_test.py'
+    - '__init__.py'    
   description: Modules should have docstrings
   explanation: |
     Modules (Python files) should start with docstrings describing the contents and usage of the module.


### PR DESCRIPTION
fixes: https://github.com/sourcery-ai/sourcery/issues/323